### PR TITLE
feat(source-hubspot): Add details stream for HubSpot account information

### DIFF
--- a/airbyte-integrations/connectors/source-hubspot/erd/source.dbml
+++ b/airbyte-integrations/connectors/source-hubspot/erd/source.dbml
@@ -3098,6 +3098,18 @@ Table "workflows" {
     "portalId" integer
 }
 
+Table "details" {
+    "portalId" number
+    "accountType" string
+    "additionalCurrencies" array
+    "companyCurrency" string
+    "dataHostingLocation" string
+    "timeZone" string
+    "uiDomain" string
+    "utcOffset" string
+    "utcOffsetMilliseconds" number
+}
+
 Ref {
     "companies"."properties_hs_created_by_user_id" <> "owners"."userId"
 }

--- a/airbyte-integrations/connectors/source-hubspot/integration_tests/basic_read_catalog.json
+++ b/airbyte-integrations/connectors/source-hubspot/integration_tests/basic_read_catalog.json
@@ -359,6 +359,15 @@
       },
       "sync_mode": "full_refresh",
       "destination_sync_mode": "overwrite"
+    },
+    {
+      "stream": {
+        "name": "details",
+        "json_schema": {},
+        "supported_sync_modes": ["full_refresh"]
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     }
   ]
 }

--- a/airbyte-integrations/connectors/source-hubspot/integration_tests/full_refresh_oauth_catalog.json
+++ b/airbyte-integrations/connectors/source-hubspot/integration_tests/full_refresh_oauth_catalog.json
@@ -206,6 +206,15 @@
       },
       "sync_mode": "full_refresh",
       "destination_sync_mode": "overwrite"
+    },
+    {
+      "stream": {
+        "name": "details",
+        "json_schema": {},
+        "supported_sync_modes": ["full_refresh"]
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     }
   ]
 }

--- a/airbyte-integrations/connectors/source-hubspot/manifest.yaml
+++ b/airbyte-integrations/connectors/source-hubspot/manifest.yaml
@@ -1977,6 +1977,31 @@ definitions:
             $ref: "#/schemas/tickets"
         - $ref: "#/definitions/base_dynamic_schema_loader"
 
+  details_stream:
+    $ref: "#/definitions/stream_without_pagination"
+    name: details
+    retriever:
+      type: SimpleRetriever
+      decoder:
+        type: JsonDecoder
+      requester:
+        $ref: "#/definitions/base_requester"
+        path: /account-info/v3/details
+        http_method: GET
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path: []
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        $ref: "#/schemas/details"
+    $parameters:
+      name: details
+      path: /account-info/v3/details
+      required_scopes: oauth
+
 streams:
   - "#/definitions/campaigns_stream"
   - "#/definitions/companies_stream"
@@ -2010,6 +2035,7 @@ streams:
   - "#/definitions/ticket_pipelines_stream"
   - "#/definitions/tickets_stream"
   - "#/definitions/workflows_stream"
+  - "#/definitions/details_stream"
 
 dynamic_streams:
   - type: DynamicDeclarativeStream
@@ -2375,6 +2401,48 @@ concurrency_level:
   max_concurrency: 40
 
 schemas:
+  details:
+    $schema: http://json-schema.org/draft-07/schema#
+    type: object
+    additionalProperties: true
+    properties:
+      accountType:
+        type:
+          - "string"
+          - "null"
+      additionalCurrencies:
+        type:
+          - "array"
+          - "null"
+      companyCurrency:
+        type:
+          - "string"
+          - "null"
+      dataHostingLocation:
+        type:
+          - "string"
+          - "null"
+      portalId:
+        type:
+          - "number"
+          - "null"
+      timeZone:
+        type:
+          - "string"
+          - "null"
+      uiDomain:
+        type:
+          - "string"
+          - "null"
+      utcOffset:
+        type:
+          - "string"
+          - "null"
+      utcOffsetMilliseconds:
+        type:
+          - "number"
+          - "null"
+
   contact_lists:
     $schema: http://json-schema.org/draft-07/schema#
     type:


### PR DESCRIPTION
## Summary
This PR adds a new `details` stream to the HubSpot source connector that provides access to account-level information and metadata.

## Changes
- **New Stream**: Added `details` stream with full refresh sync mode
- **Endpoint**: `/account-info/v3/details` 
- **Authentication**: Reuses existing connector authentication patterns
- **Error Handling**: Inherits base error handling and rate limiting

## Schema
The new stream includes the following fields:
- `portalId` (number) - HubSpot account portal ID
- `accountType` (string) - Type of HubSpot account
- `additionalCurrencies` (array) - Additional supported currencies
- `companyCurrency` (string) - Primary account currency
- `dataHostingLocation` (string) - Data hosting location
- `timeZone` (string) - Account timezone
- `uiDomain` (string) - UI domain for the account
- `utcOffset` (string) - UTC offset
- `utcOffsetMilliseconds` (number) - UTC offset in milliseconds

## Technical Details
- Stream definition follows existing HubSpot connector patterns
- Uses `stream_without_pagination` base configuration
- Schema is properly typed with null safety
- Full refresh mode appropriate for account metadata

## Testing
- ✅ Connector builds successfully for linux/amd64
- ✅ Schema validation passes
- ✅ Integration with existing authentication works
- ✅ Docker images available: 1.0.0 (baseline), 1.0.1 (with details stream)

## Breaking Changes
None - this is a purely additive change that doesn't affect existing streams.

## Registry Images
- `us-central1-docker.pkg.dev/vascohq-dev/docker-containers/source-hubspot:1.0.0` - Official baseline
- `us-central1-docker.pkg.dev/vascohq-dev/docker-containers/source-hubspot:1.0.1` - With details stream